### PR TITLE
Escape displayed URL as well as mobile URL

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -36,7 +36,7 @@ class Article < ActiveRecord::Base
   end
 
   private
-
+  # CGI.escape will convert spaces to '+' which will break the URL
   def escaped_title
     title.tr(' ', '_')
   end
@@ -50,7 +50,7 @@ class Article < ActiveRecord::Base
   end
 
   def url
-    "https://en.wikipedia.org/wiki/#{escaped_title}"
+    "https://en.wikipedia.org/wiki/#{CGI.escape(escaped_title)}"
   end
 
   def mobile_url


### PR DESCRIPTION
Avoids breaking tweets like this: https://twitter.com/FixmeBot/status/685627054549811200

Also adds comment what we're doing with 'escaped_title'